### PR TITLE
Add two-step action

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 This action will be triggered on comments on pull requests: it checks-out your pull request, runs a command, and commits the result back to the branch. It can also write a comment on the PR.
 
-There is a [simple](simple/README.md) and an [advanced action](advanced/README.md)
+There is:
+* a [simple action](simple/README.md), reacting to a given comment with a given command;
+* an [advanced action](advanced/README.md), reacting to comments starting with a given prefix, with commands that depend on the actual comment;
+* a composite [two-steps action](check-run/README.md), separating the process of the comment and the run of the command to leave room for extra setup should a command be run.
 
 ![Example](https://user-images.githubusercontent.com/25243461/150767980-d6c82e0a-e8a6-4e9e-8e29-07a2133ee65c.png)

--- a/check-run/README.md
+++ b/check-run/README.md
@@ -1,0 +1,46 @@
+# Pull Request Commands - Separate check and run steps
+
+This version splits the actions in two parts: one that checks whether the action should run and does some basic setup (checkout the repository, handle the `help` command, …); the other that performs the actual action. Between the two actions, it is possible to interpose repository-specific commands, especially the ones that are used by all PR Commands flow (e.g., `actions/setup-node`, `install`, `build`, or `test`, …)
+
+The `config.json` file, options, and token restriction follows the exact same syntax as for the [advanced action](../advanced).
+
+<!-- start usage -->
+**.github/workflows/pr-command.yaml**
+```yaml
+name: <insert action name>
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  <insert action name>:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Should PR Commands run?"
+        uses: siteimprove/pr-command/check-run/check@v2
+        with:
+          # Personal access token (PAT) used to fetch the repository and add reaction on comment (See note about token)
+          token: ''
+
+      # At this point, repository specific setup can be performed before running the actual PR commands.
+      # The repository has been checked out, on the latest commit on the PR that triggered the workflow.
+      # All steps should be conditional with "if: env.PR_COMMAND_WILL_RUN == 'true'" to ensure they are
+      # only run if needed.
+      # The 'check' action has set two environement variables:
+      # * PR_COMMAND_WILL_RUN is 'true' iff check determined the comment triggers an existing command.
+      # * PR_COMMAND_DETAILS is a JSON object containing the details of the command, as read from the config file.
+      
+      - name: "Conditional stuff"
+        if: env.PR_COMMAND_WILL_RUN == 'true'
+        run: |
+          echo "I should probably do stuff"
+          echo $PR_COMMAND_DETAILS
+      
+      - name: "Do stuff"
+        uses: siteimprove/pr-command/check-run/run@v2
+        with:
+          # Personal access token (PAT) used to fetch the repository and add reaction on comment (See note about token)
+          token: ''
+```
+<!-- end usage -->

--- a/check-run/README.md
+++ b/check-run/README.md
@@ -27,7 +27,7 @@ jobs:
       # The repository has been checked out, on the latest commit on the PR that triggered the workflow.
       # All steps should be conditional with "if: env.PR_COMMAND_WILL_RUN == 'true'" to ensure they are
       # only run if needed.
-      # The 'check' action has set two environement variables:
+      # The 'check' action has set two environment variables:
       # * PR_COMMAND_WILL_RUN is 'true' iff check determined the comment triggers an existing command.
       # * PR_COMMAND_DETAILS is a JSON object containing the details of the command, as read from the config file.
       

--- a/check-run/check/action.yaml
+++ b/check-run/check/action.yaml
@@ -1,0 +1,131 @@
+name: Pull Request command (Check if it should run)
+description: "pr-command is an action that enables you to run commands on your pull requests using comments."
+
+inputs:
+  token:
+    description: "Authentication token for GitHub repository"
+    required: true
+  prefix:
+    description: "Prefix for commands, defaults to '!pr"
+    required: false
+    default: '!pr'
+
+runs:
+  using: "composite"
+  steps:
+    - name: 'Should handle PR comment?'
+      run: |
+        if [[ "${{github.event.issue.pull_request && startsWith(github.event.comment.body, inputs.prefix)}}" == "false" ]]; then
+          echo "should_run=false" >> $GITHUB_OUTPUT
+        else
+          echo "should_run=true" >> $GITHUB_OUTPUT
+        fi
+      id: check
+      shell: bash
+
+    - name: "Get PR details"
+      uses: actions/github-script@v6
+      id: get-pr
+      with:
+        script: |
+          const request = {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          }
+          core.info(`Getting PR #${request.pull_number} from ${request.owner}/${request.repo}`)
+          try {
+            const result = await github.rest.pulls.get(request)
+            return result.data
+          } catch (err) {
+            core.setFailed(`Request failed with error ${err}`)
+          }
+
+    - name: "Checkout repository"
+      uses: actions/checkout@v3
+      with:
+        token: ${{ inputs.token }}
+        repository: ${{ fromJSON(steps.get-pr.outputs.result).head.repo.full_name }}
+        ref: ${{ fromJSON(steps.get-pr.outputs.result).head.ref }}
+        fetch-depth: 0
+
+    - name: "Does configuration file exists?"
+      if: steps.check.outputs.should_run == 'true'
+      run: |
+        if [[ -f ./.pr-commands/config.json ]]; then
+          echo "has_config=true" >> $GITHUB_OUTPUT
+        else
+          echo "Pr-commands config file (.pr-commands/config.json) does not exist"
+          exit 1
+        fi
+      id: config
+      shell: bash
+
+    - name: "Read configuration file"
+      if: steps.config.outputs.has_config == 'true'
+      run: |
+        echo 'CONFIG_JSON<<EOF' >> $GITHUB_ENV
+        cat ./.pr-commands/config.json >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+      shell: bash
+
+    - name: "Should print help?"
+      run: echo "is_help=true" >> $GITHUB_OUTPUT
+      if: steps.config.outputs.has_config == 'true' && startsWith(github.event.comment.body, format('{0} {1}', inputs.prefix, 'help'))
+      id: help_check
+      shell: bash
+
+    - name: "Print help"
+      if: steps.help_check.outputs.is_help == 'true'
+      uses: actions/github-script@v6
+      env:
+        PREFIX: ${{ inputs.prefix }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const prefix = process.env.PREFIX
+          const jsonObject = JSON.parse(process.env.CONFIG_JSON);
+          let message = `Hi there 👋 \n\n You have the following options: \n - \`${prefix} help\` writes this comment`;
+          for (let [key, value] of Object.entries(jsonObject))
+            message = message + `\n - \`${prefix} ${key}\` ${value.description}`;
+          github.rest.issues.createComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            issue_number: context.payload.issue.number,
+            body: message
+          });
+
+    - name: "Get PR Command details"
+      if: steps.config.outputs.has_config == 'true' && steps.help_check.outputs.is_help != 'true'
+      uses: actions/github-script@v6
+      id: command_details
+      env:
+        PREFIX: ${{ inputs.prefix }}
+        COMMENT: ${{ github.event.comment.body }}
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const prefix = process.env.PREFIX
+          const command = process.env.COMMENT.replace(prefix, '').trimStart()
+          const jsonObject = JSON.parse(process.env.CONFIG_JSON);
+          if (!Object.keys(jsonObject).includes(command)) {
+            console.log(`Command \`${command}\` is not defined`)
+            process.exit(1)
+          }
+          core.exportVariable("PR_COMMAND_WILL_RUN", jsonObject[command].command !== undefined);
+          core.exportVariable("PR_COMMAND_DETAILS", JSON.stringify(jsonObject[command]));
+
+    - name: "React with Emoji on start"
+      if: env.PR_COMMAND_WILL_RUN == 'true'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const jsonObject = JSON.parse(process.env.PR_COMMAND_DETAILS);
+          if (jsonObject.startEmoji === null) return
+          github.rest.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: (jsonObject.startEmoji || 'rocket')
+          });

--- a/check-run/run/action.yaml
+++ b/check-run/run/action.yaml
@@ -1,0 +1,76 @@
+name: Pull Request command (Run the command)
+description: "pr-command is an action that enables you to run commands on your pull requests using comments."
+
+inputs:
+  token:
+    description: "Authentication token for GitHub repository"
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: "Handle PR Command"
+      if: env.PR_COMMAND_WILL_RUN == 'true'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const jsonObject = JSON.parse(process.env.PR_COMMAND_DETAILS);
+          console.log("I will run", jsonObject.command)
+          let myOutput = '';
+          if (jsonObject.command) {
+            const options = {};
+            options.listeners = {
+              stdout: (data) => {
+                myOutput += data.toString();
+              },
+              stderr: (data) => {
+                myOutput += data.toString();
+              }
+            };
+            const execres = await exec.exec(`bash -c "${jsonObject.command}"`, undefined, options)
+            if (execres != 0) process.exit(execres)
+          }
+          console.log("I will commit", jsonObject.commitMsg)
+          if (jsonObject.commitMsg) {
+            const execres = await exec.exec(`bash -c "git config user.name github-actions && git config user.email 41898282+github-actions[bot]@users.noreply.github.com && git add . && (git commit -m '${jsonObject.commitMsg}' || true) && git push --force-with-lease"`)
+            if (execres != 0) process.exit(execres)
+          }
+          console.log("I will write", jsonObject.commentMsg)
+          if (jsonObject.commentMsg) {
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.issue.number,
+              body: `${jsonObject.commentMsg.replace('<COMMAND_RESULT>', myOutput)}`
+            });
+          }
+
+    - name: "React with Emoji on success"
+      if: success() && env.PR_COMMAND_WILL_RUN == 'true'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const jsonObject = JSON.parse(process.env.PR_COMMAND_DETAILS);
+          console.log("I put on a", jsonObject.successEmoji)
+          if (jsonObject.successEmoji === null) return
+          github.rest.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: (jsonObject.successEmoji || 'hooray')
+          });
+
+    - name: 'Failure: React with confused'
+      if: failure() && env.PR_COMMAND_WILL_RUN == 'true'
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          github.rest.reactions.createForIssueComment({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            comment_id: context.payload.comment.id,
+            content: 'confused'
+          });


### PR DESCRIPTION
Closes #7 

Add an action, splitting the advanced one in two so that repo-specific steps can be added between the check and the actual run.

Note that both the advanced and two-steps action share the same config file (as it is hardcoded, not passed as input), so it is not possible to run both (even with different prefix), in case only some commands require the extra setup 😕 It is still possible to run individual simple actions, however…

I assumed this will be released as 2.2 since it is backward compatible (old actions aren't touched), so kept the `v2` tag in README.

I've tried that on https://github.com/Siteimprove/alfa-companion/pull/11 Seems to work… But local actions are a bit different than global ones (notably requiring to checkout the repo first), so I'm not fully sure this works 🤞 😬 