### PR TITLE
Configurable config file location

### DIFF
--- a/check-run/README.md
+++ b/check-run/README.md
@@ -2,7 +2,7 @@
 
 This version splits the actions in two parts: one that checks whether the action should run and does some basic setup (checkout the repository, handle the `help` command, …); the other that performs the actual action. Between the two actions, it is possible to interpose repository-specific commands, especially the ones that are used by all PR Commands flow (e.g., `actions/setup-node`, `install`, `build`, or `test`, …)
 
-The `config.json` file, options, and token restriction follows the exact same syntax as for the [advanced action](../advanced).
+The configuration file can be parametrised via the `configFile` input, the default location is `./config/pr-commands.json`. It otherwise follows the exact same syntax as for the [advanced action](../advanced).
 
 <!-- start usage -->
 **.github/workflows/pr-command.yaml**
@@ -22,6 +22,10 @@ jobs:
         with:
           # Personal access token (PAT) used to fetch the repository and add reaction on comment (See note about token)
           token: ''
+          # Optional prefix to trigger the command, defaults to "!pr"
+          prefix: "Magic bot, please run"
+          # Configuration file location (relative to top-level directoy), defaults to "./config/pr-commands.json"
+          configFile: "./.pr-commands/config.json"
 
       # At this point, repository specific setup can be performed before running the actual PR commands.
       # The repository has been checked out, on the latest commit on the PR that triggered the workflow.

--- a/check-run/README.md
+++ b/check-run/README.md
@@ -24,7 +24,7 @@ jobs:
           token: ''
           # Optional prefix to trigger the command, defaults to "!pr"
           prefix: "Magic bot, please run"
-          # Configuration file location (relative to top-level directoy), defaults to "./config/pr-commands.json"
+          # Configuration file location (relative to top-level directory), defaults to "./config/pr-commands.json"
           configFile: "./.pr-commands/config.json"
 
       # At this point, repository specific setup can be performed before running the actual PR commands.

--- a/check-run/check/action.yaml
+++ b/check-run/check/action.yaml
@@ -9,6 +9,11 @@ inputs:
     description: "Prefix for commands, defaults to '!pr"
     required: false
     default: '!pr'
+  configFile:
+    description: "Location of the configuration file"
+    required: false
+    default: "./config/pr-commands.json"
+
 
 runs:
   using: "composite"
@@ -52,7 +57,7 @@ runs:
     - name: "Does configuration file exists?"
       if: steps.check.outputs.should_run == 'true'
       run: |
-        if [[ -f ./.pr-commands/config.json ]]; then
+        if [[ -f ${{ inputs.configFile }} ]]; then
           echo "has_config=true" >> $GITHUB_OUTPUT
         else
           echo "Pr-commands config file (.pr-commands/config.json) does not exist"
@@ -65,7 +70,7 @@ runs:
       if: steps.config.outputs.has_config == 'true'
       run: |
         echo 'CONFIG_JSON<<EOF' >> $GITHUB_ENV
-        cat ./.pr-commands/config.json >> $GITHUB_ENV
+        cat ${{ inputs.configFile }} >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
       shell: bash
 


### PR DESCRIPTION
Makes the config file location configurable.
Defaults to `./config/pr-commands.json` because it seems that `./config` is a semi-standard location in the JS ecosystem… This is effectively breaking previous actions, I guess not much already use the check-run action. When migrating from the advanced action, config file location needs to be changed or provided.
(note that this allows several check-run or advanced actions to run in the same repo with different prefix and config file, to perform different steps between the check and the run)